### PR TITLE
server: move server to ORTC

### DIFF
--- a/htdocs/index.html
+++ b/htdocs/index.html
@@ -5,6 +5,7 @@
     <title>WebRTC WPT demo</title>
     <script src="https://wpt.live/resources/testharness.js"></script>
     <script src="https://wpt.live/resources/testharnessreport.js"></script>
+    <script src="https://wpt.live/webrtc/third_party/sdp/sdp.js"></script>
     <script src="lib.js"></script>
 </head>
 <body>


### PR DESCRIPTION
The potential advantage of this approach is that we can reduce the serverside logic (no dependency on codecs, headerextensions, etc) when only returning a set of ice and dtls parameters and putting the "SDP" creation on the  test.

(oh I missed working with an ORTC-style library... such a pleasure)