### PR TITLE
allow tests to send a offer

### DIFF
--- a/htdocs/bye.html
+++ b/htdocs/bye.html
@@ -24,8 +24,11 @@ promise_test(async (t) => {
         pc.addTrack(track, stream);
     });
 
-    const ws = await connect(pc);
-    t.add_cleanup(() => ws.close());
+    const helper = new WebRTCHelper(pc);
+    t.add_cleanup(() => helper.cleanup());
+
+    const ws = await helper.connect();
+    await helper.offer();
 
     // Wait for the first RTP packet.
     await (new Promise((resolve) => {

--- a/htdocs/index.html
+++ b/htdocs/index.html
@@ -22,9 +22,11 @@ promise_test(async (t) => {
     stream.getTracks().forEach((track) => {
         pc.addTrack(track, stream);
     });
+    const helper = new WebRTCHelper(pc);
+    t.add_cleanup(() => helper.cleanup());
 
-    const ws = await connect(pc);
-    t.add_cleanup(() => ws.close());
+    const ws = await helper.connect();
+    await helper.offer();
 
     // Wait for a video frame. The last packet in the frame will have the marker bit set.
     // Note that this doesn't deal well with conditions like missing last packets, however
@@ -38,7 +40,7 @@ promise_test(async (t) => {
             const rtpData = new RTP(message.data);
             buffer.push(rtpData);
             if (rtpData.marker) {
-                ws.removeEventListener('message', listener);
+                helper.ws.removeEventListener('message', listener);
                 resolve(buffer);
             }
         });

--- a/htdocs/nack.html
+++ b/htdocs/nack.html
@@ -23,8 +23,29 @@ promise_test(async (t) => {
         pc.addTrack(track, stream);
     });
 
-    const ws = await connect(pc);
-    t.add_cleanup(() => ws.close());
+    const helper = new WebRTCHelper(pc);
+    t.add_cleanup(() => helper.cleanup());
+    const ws = await helper.connect();
+
+    const parameters = await helper.getRemoteParameters();
+    let sdp = 'v=0\r\n' +
+        'o=- 166855176514521964 2 IN IP4 127.0.0.1\r\n' +
+        's=-\r\n' +
+        't=0 0\r\n' +
+        'm=video 9 UDP/TLS/RTP/SAVPF 100 101\r\n' +
+        'c=IN IP4 0.0.0.0\r\n' +
+        'a=rtcp:9 IN IP4 0.0.0.0\r\n' +
+        'a=mid:0\r\n' +
+        'a=sendrecv\r\n' +
+        'a=rtcp-mux\r\n' +
+        'a=rtcp-rsize\r\n' +
+        'a=rtpmap:100 VP8/90000\r\n' +
+        'a=rtpmap:101 rtx/90000\r\n' +
+        'a=fmtp:101 apt=100\r\n';
+    sdp += SDPUtils.writeDtlsParameters(parameters.dtls, 'actpass');
+    sdp += SDPUtils.writeIceParameters(parameters.ice);
+    parameters.candidates.forEach(c => sdp += 'a=' + c + '\r\n');
+    await helper.answer(sdp);
 
     // Wait for the first non-padding RTP packet.
     const packet =  await (new Promise((resolve) => {
@@ -73,6 +94,7 @@ promise_test(async (t) => {
             // https://tools.ietf.org/html/rfc4588#section-4
             const osn = rtpData.payload.getUint16(0);
             if (osn === packet.sequenceNumber) {
+                ws.removeEventListener('message', listener);
                 resolve();
             }
         });
@@ -91,7 +113,7 @@ promise_test(async (t) => {
         }
     });
     assert_equals(nackCount, 1, 'nackCount shows received NACK');
-}, 'NACK behaviour');
+}, 'NACK behaviour with RTX');
 </script>
 </body>
 </html>

--- a/htdocs/simulcast.html
+++ b/htdocs/simulcast.html
@@ -52,8 +52,11 @@ promise_test(async (t) => {
         sendEncodings: rids.map(rid => ({rid})),
     });
 
-    const ws = await connect(pc);
-    t.add_cleanup(() => ws.close());
+    const helper = new WebRTCHelper(pc);
+    t.add_cleanup(() => helper.cleanup());
+
+    const ws = await helper.connect();
+    await helper.offer();
 
     await Promise.all(rids.map(rid => waitForRid(ws, rid)));
 }, 'simulcast sends packet with RID extension');
@@ -72,9 +75,11 @@ promise_test(async (t) => {
         streams: [stream],
         sendEncodings: rids.map(rid => ({rid})),
     });
+    const helper = new WebRTCHelper(pc);
+    t.add_cleanup(() => helper.cleanup());
 
-    const ws = await connect(pc);
-    t.add_cleanup(() => ws.close());
+    const ws = await helper.connect();
+    await helper.offer();
 
     const packet = new RTP(await waitForRid(ws, 'l'));
     const firstByte = packet.payload.getUint8(0);


### PR DESCRIPTION
and send back an answer. Note that this assumes the handling of ice role conflicts works.

@jlaine I get flaky failures on nack.html with this one. It is pretty odd, in chrome://webrtc-internals one can see that
1/ iceconnectionstate goes to connected
2/ legacy iceconnectionstate goes to connected (that is the old combined ice+dtls one)
3/ connectionstate goes to failed immediately.

webrtc-internals dump: [tlsfail.txt](https://github.com/jlaine/aiortc-wpt-demo/files/6254300/tlsfail.txt)
pcap: [dtls-fail.zip](https://github.com/jlaine/aiortc-wpt-demo/files/6254310/dtls-fail.zip)
There is a DTLS client hello from Chrome in packet 295 and then a fragmented one from aiortc in packet 300.
One of them is wrong, not sure which side.